### PR TITLE
Updated RavenDB dependencies to 3.5.1 and targeted .Net 4.5.1

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ A RavenDB plugin and client that automatically maintains previous versions of a 
 * Your application controls the Revision number and not the plugin.
 * Your application is resposible for revision number contiguity.
 
-While Raven's 'Versioning' bundle is designed for regulatad environments, such as healtcare, where nothing can be deleted, this bundle is more useful for applications where the document is a result of a projection (i.e. CQRS) and where the 'source of truth' comes from somewhere else and where projections / documents can easily be rebuilt.
+While Raven's 'Versioning' bundle is designed for regulated environments, such as healtcare, where nothing can be deleted, this bundle is more useful for applications where the document is a result of a projection (i.e. CQRS) and where the 'source of truth' comes from somewhere else and where projections / documents can easily be rebuilt.
 
 
 

--- a/src/Raven.Bundles.Revisions.Tests/Raven.Bundles.Revisions.Tests.csproj
+++ b/src/Raven.Bundles.Revisions.Tests/Raven.Bundles.Revisions.Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Raven.Bundles.Revisions</RootNamespace>
     <AssemblyName>Raven.Bundles.Revisions.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -38,16 +38,20 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Raven.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Database.3.0.30155\lib\net45\Raven.Abstractions.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Raven.Client.Lightweight, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Client.3.0.30155\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+    <Reference Include="Raven.Abstractions, Version=3.5.1.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
+      <HintPath>..\packages\RavenDB.Database.3.5.1\lib\net45\Raven.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Raven.Database, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Database.3.0.30155\lib\net45\Raven.Database.dll</HintPath>
+    <Reference Include="Raven.Client.Lightweight, Version=3.5.1.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
+      <HintPath>..\packages\RavenDB.Client.3.5.1\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Raven.Database, Version=3.5.1.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
+      <HintPath>..\packages\RavenDB.Database.3.5.1\lib\net45\Raven.Database.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Raven.Bundles.Revisions.Tests/RevisionDocumentDatabaseTests.cs
+++ b/src/Raven.Bundles.Revisions.Tests/RevisionDocumentDatabaseTests.cs
@@ -90,8 +90,10 @@ namespace Tests.Raven.Bundles.Revisions
 
             using (var session = _documentStore.OpenAsyncSession())
             {
-                var myVersionedDocuments =
-                    await session.Query<RevisionedDocument>().Customize(q => q.WaitForNonStaleResults()).ToListAsync();
+                var myVersionedDocuments = await session
+                    .Query<RevisionedDocument>()
+                    .Customize(q => q.WaitForNonStaleResults())
+                    .ToListAsync();
 
                 Assert.Equal(1, myVersionedDocuments.Count);
                 Assert.Equal("key", myVersionedDocuments[0].Id);

--- a/src/Raven.Bundles.Revisions.Tests/app.config
+++ b/src/Raven.Bundles.Revisions.Tests/app.config
@@ -20,7 +20,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.8.0" newVersion="4.0.8.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NLog" publicKeyToken="5120e14c03d0593c" culture="neutral" />
@@ -28,4 +28,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" /></startup></configuration>

--- a/src/Raven.Bundles.Revisions.Tests/packages.config
+++ b/src/Raven.Bundles.Revisions.Tests/packages.config
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RavenDB.Client" version="3.0.30155" targetFramework="net45" />
-  <package id="RavenDB.Database" version="3.0.30155" targetFramework="net45" />
-  <package id="xunit" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
+  <package id="RavenDB.Client" version="3.5.1" targetFramework="net451" />
+  <package id="RavenDB.Database" version="3.5.1" targetFramework="net451" />
+  <package id="xunit" version="2.1.0" targetFramework="net451" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net451" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net451" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net451" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net451" />
 </packages>

--- a/src/Raven.Bundles.Revisions/HideRevisionDocumentsFromIndexingReadTrigger.cs
+++ b/src/Raven.Bundles.Revisions/HideRevisionDocumentsFromIndexingReadTrigger.cs
@@ -30,18 +30,17 @@ namespace Raven.Bundles.Revisions
 
     public class HideRevisionDocumentsFromIndexingReadTrigger : AbstractReadTrigger
     {
-        public override ReadVetoResult AllowRead(string key,
+        public override ReadVetoResult AllowRead(
+            string key,
             RavenJObject metadata,
             ReadOperation operation,
             TransactionInformation transactionInformation)
         {
-            if (operation != ReadOperation.Index)
-            {
-                return ReadVetoResult.Allowed;
-            }
-            return key.Contains(RevisionDocumentPutTrigger.RevisionSegment)
-                ? ReadVetoResult.Ignore
-                : ReadVetoResult.Allowed;
+            return operation != ReadOperation.Index
+                ? ReadVetoResult.Allowed
+                : (key.Contains(RevisionDocumentPutTrigger.RevisionSegment)
+                    ? ReadVetoResult.Ignore
+                    : ReadVetoResult.Allowed);
         }
     }
 }

--- a/src/Raven.Bundles.Revisions/Raven.Bundles.Revisions.csproj
+++ b/src/Raven.Bundles.Revisions/Raven.Bundles.Revisions.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Raven.Bundles.Revisions</RootNamespace>
     <AssemblyName>Raven.Bundles.Revisions</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -103,16 +103,20 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Raven.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Database.3.0.30155\lib\net45\Raven.Abstractions.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Raven.Client.Lightweight, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Client.3.0.30155\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+    <Reference Include="Raven.Abstractions, Version=3.5.1.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
+      <HintPath>..\packages\RavenDB.Database.3.5.1\lib\net45\Raven.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Raven.Database, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Database.3.0.30155\lib\net45\Raven.Database.dll</HintPath>
+    <Reference Include="Raven.Client.Lightweight, Version=3.5.1.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
+      <HintPath>..\packages\RavenDB.Client.3.5.1\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Raven.Database, Version=3.5.1.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
+      <HintPath>..\packages\RavenDB.Database.3.5.1\lib\net45\Raven.Database.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Raven.Bundles.Revisions/RevisionDocumentPutTrigger.cs
+++ b/src/Raven.Bundles.Revisions/RevisionDocumentPutTrigger.cs
@@ -33,7 +33,8 @@ namespace Raven.Bundles.Revisions
     {
         internal const string RevisionSegment = "/revision/";
 
-        public override VetoResult AllowPut(string key,
+        public override VetoResult AllowPut(
+            string key,
             RavenJObject document,
             RavenJObject metadata,
             TransactionInformation transactionInformation)
@@ -43,7 +44,8 @@ namespace Raven.Bundles.Revisions
                 : VetoResult.Allowed;
         }
 
-        public override void OnPut(string key,
+        public override void OnPut(
+            string key,
             RavenJObject document,
             RavenJObject metadata,
             TransactionInformation transactionInformation)
@@ -57,11 +59,10 @@ namespace Raven.Bundles.Revisions
             using (Database.DisableAllTriggersForCurrentThread())
             {
                 var revisionCopy = new RavenJObject(document);
+                var revisionKey  = $"{key}{RevisionSegment}{versionToken.Value<int>()}";
 
-                var revisionkey = key + RevisionSegment + versionToken.Value<int>();
-
-                Database.TransactionalStorage.Batch(
-                    storage => storage.Documents.AddDocument(revisionkey, null, revisionCopy, metadata));
+                Database.TransactionalStorage.Batch(storage => 
+                    storage.Documents.AddDocument(revisionKey, null, revisionCopy, metadata));
             }
         }
     }

--- a/src/Raven.Bundles.Revisions/app.config
+++ b/src/Raven.Bundles.Revisions/app.config
@@ -16,7 +16,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.8.0" newVersion="4.0.8.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NLog" publicKeyToken="5120e14c03d0593c" culture="neutral" />
@@ -24,4 +24,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" /></startup></configuration>

--- a/src/Raven.Bundles.Revisions/packages.config
+++ b/src/Raven.Bundles.Revisions/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.0.8" />
-  <package id="NLog" version="2.0.0.2000" />
-  <package id="RavenDB.Client" version="3.0.30155" targetFramework="net45" />
-  <package id="RavenDB.Database" version="3.0.30155" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
+  <package id="RavenDB.Client" version="3.5.1" targetFramework="net451" />
+  <package id="RavenDB.Database" version="3.5.1" targetFramework="net451" />
 </packages>

--- a/src/Raven.Client.Revisions/AsyncDatabaseCommandsExtensions.cs
+++ b/src/Raven.Client.Revisions/AsyncDatabaseCommandsExtensions.cs
@@ -1,8 +1,8 @@
-﻿#region CopyrightAndLicence
+#region CopyrightAndLicence
 
 // --------------------------------------------------------------------------------------------------------------------
-// <Copyright company="Damian Hickey" file="IDocumentSessionExtensions.cs">
-// 	Copyright © 2012 Damian Hickey
+// <Copyright company="Damian Hickey" file="AsyncDatabaseCommandsExtensions.cs">
+// 	Copyright � 2012 Damian Hickey
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 // documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
@@ -27,23 +27,22 @@ namespace Raven.Client.Revisions
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using Raven.Client.Connection.Async;
 
-    public static class IDocumentSessionExtensions
+    public static class AsyncDatabaseCommandsExtensions
     {
-        public static Task<T> LoadRevision<T>(this IAsyncDocumentSession session, string id, int revision,
+        public static Task DeleteRevision(this IAsyncDatabaseCommands databaseCommands,
+            string id,
+            int revision,
+            Guid? etag = default(Guid?),
             CancellationToken ct = default(CancellationToken))
         {
-            if (session == null)
-            {
-                throw new ArgumentNullException(nameof(session));
-            }
-            if (id == null)
-            {
-                throw new ArgumentNullException(nameof(id));
-            }
+            if (databaseCommands == null) throw new ArgumentNullException(nameof(databaseCommands));
+            if (id == null) throw new ArgumentNullException(nameof(id));
+
             var revisionDocId = RevisionDocIdGenerator.GetId(id, revision);
 
-            return session.LoadAsync<T>(revisionDocId, ct);
+            return databaseCommands.DeleteAsync(revisionDocId, etag, ct);
         }
     }
 }

--- a/src/Raven.Client.Revisions/AsyncDocumentSessionExtensions.cs
+++ b/src/Raven.Client.Revisions/AsyncDocumentSessionExtensions.cs
@@ -1,8 +1,8 @@
-#region CopyrightAndLicence
+﻿#region CopyrightAndLicence
 
 // --------------------------------------------------------------------------------------------------------------------
-// <Copyright company="Damian Hickey" file="IDatabaseCommandsExtensions.cs">
-// 	Copyright � 2012 Damian Hickey
+// <Copyright company="Damian Hickey" file="AsyncDocumentSessionExtensions.cs">
+// 	Copyright © 2012 Damian Hickey
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 // documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
@@ -27,25 +27,20 @@ namespace Raven.Client.Revisions
     using System;
     using System.Threading;
     using System.Threading.Tasks;
-    using Raven.Client.Connection.Async;
 
-    public static class IDatabaseCommandsExtensions
+    public static class AsyncDocumentSessionExtensions
     {
-        public static Task DeleteRevision(this IAsyncDatabaseCommands databaseCommands, string id, int revision,
-            Guid? etag = default(Guid?), CancellationToken ct = default(CancellationToken))
+        public static Task<T> LoadRevision<T>(this IAsyncDocumentSession session,
+            string id,
+            int revision,
+            CancellationToken ct = default(CancellationToken))
         {
-            if (databaseCommands == null)
-            {
-                throw new ArgumentNullException(nameof(databaseCommands));
-            }
-            if (id == null)
-            {
-                throw new ArgumentNullException(nameof(id));
-            }
+            if (session == null) throw new ArgumentNullException(nameof(session));
+            if (id == null) throw new ArgumentNullException(nameof(id));
 
             var revisionDocId = RevisionDocIdGenerator.GetId(id, revision);
 
-            return databaseCommands.DeleteAsync(revisionDocId, etag, ct);
+            return session.LoadAsync<T>(revisionDocId, ct);
         }
     }
 }

--- a/src/Raven.Client.Revisions/Guard.cs
+++ b/src/Raven.Client.Revisions/Guard.cs
@@ -30,10 +30,7 @@ namespace Raven.Client.Revisions
     {
         internal static void Against(bool condition, Func<Exception> exceptionFactory)
         {
-            if (condition)
-            {
-                throw exceptionFactory();
-            }
+            if (condition) throw exceptionFactory();
         }
     }
 }

--- a/src/Raven.Client.Revisions/Raven.Client.Revisions.csproj
+++ b/src/Raven.Client.Revisions/Raven.Client.Revisions.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Raven.Client.Revisions</RootNamespace>
     <AssemblyName>Raven.Client.Revisions</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -103,12 +103,16 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Raven.Abstractions, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Client.3.0.30155\lib\net45\Raven.Abstractions.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Raven.Client.Lightweight, Version=3.0.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
-      <HintPath>..\packages\RavenDB.Client.3.0.30155\lib\net45\Raven.Client.Lightweight.dll</HintPath>
+    <Reference Include="Raven.Abstractions, Version=3.5.1.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
+      <HintPath>..\packages\RavenDB.Client.3.5.1\lib\net45\Raven.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Raven.Client.Lightweight, Version=3.5.1.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
+      <HintPath>..\packages\RavenDB.Client.3.5.1\lib\net45\Raven.Client.Lightweight.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -119,16 +123,14 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
-    <Compile Include="IDocumentSessionExtensions.cs" />
+    <Compile Include="AsyncDocumentSessionExtensions.cs" />
     <Compile Include="Guard.cs" />
-    <Compile Include="IDatabaseCommandsExtensions.cs" />
+    <Compile Include="AsyncDatabaseCommandsExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RevisionDocIdGenerator.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Raven.Client.Revisions/RevisionDocIdGenerator.cs
+++ b/src/Raven.Client.Revisions/RevisionDocIdGenerator.cs
@@ -26,9 +26,6 @@ namespace Raven.Client.Revisions
 {
     public static class RevisionDocIdGenerator
     {
-        public static string GetId(string id, int revision)
-        {
-            return id + "/revision/" + revision;
-        }
+        public static string GetId(string id, int revision) => $"{id}/revision/{revision}";
     }
 }

--- a/src/Raven.Client.Revisions/packages.config
+++ b/src/Raven.Client.Revisions/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.0.8" />
-  <package id="NLog" version="2.0.0.2000" />
-  <package id="RavenDB.Client" version="3.0.30155" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
+  <package id="RavenDB.Client" version="3.5.1" targetFramework="net451" />
 </packages>

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -1,10 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
-// <Copyright company="BEAM Financial Solutions Ltd" file="SharedAssemblyInfo.cs">
-// 	Copyright © 2009-2012 BEAM Financial Solutions Ltd
-// </Copyright>
-//  --------------------------------------------------------------------------------------------------------------------
-
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyConfiguration("")]
@@ -14,5 +8,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]


### PR DESCRIPTION
- Updated RavenDB dependencies to 3.5.1
- Now targetting .Net 4.5.1
- Updated Json.Net to 9.0.1
- Minor tweeks like string interpolation usage and formatting stuff
- Removed old Copyright from SharedAssemblyInfo
- Removed NLog
- Bumped assembly version to 2.0